### PR TITLE
Update Vagrant box name

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,11 +10,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # please see the online documentation at vagrantup.com.
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "commana/arsnova-debian-wheezy-puppet3-amd64"
+  config.vm.box = "arsnova/debian-7-amd64-puppet"
 
   # The url from where the 'config.vm.box' box will be fetched if it
   # doesn't already exist on the user's system.
-  # config.vm.box_url = "http://domain.com/path/to/above.box"
+  # config.vm.box_url = "https://arsnova.thm.de/download/vagrant/debian-7.6.0-amd64-puppet.box"
 
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine. In the example below,


### PR DESCRIPTION
This updates the name of the box in the Vagrant Cloud. While the location has changed, the image is still the same.

Fixes GH-30.